### PR TITLE
OB-10309: Add support for zip archive modules

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -29,8 +29,9 @@ const (
 )
 
 var (
-	flagJSON  bool
-	flagDebug bool
+	flagJSON                bool
+	flagDebug               bool
+	flagModuleArchiveFormat string
 
 	// S3 options.
 	flagS3Bucket    string
@@ -79,6 +80,7 @@ func Execute() {
 func init() {
 	rootCmd.PersistentFlags().BoolVar(&flagJSON, "json", false, "Enable json logging")
 	rootCmd.PersistentFlags().BoolVar(&flagDebug, "debug", false, "Enable debug logging")
+	rootCmd.PersistentFlags().StringVar(&flagModuleArchiveFormat, "storage-module-archive-format", module.DefaultArchiveFormat, "Archive file format for modules")
 	rootCmd.PersistentFlags().StringVar(&flagS3Bucket, "storage-s3-bucket", "", "S3 bucket to use for the registry")
 	rootCmd.PersistentFlags().StringVar(&flagS3Prefix, "storage-s3-prefix", "", "S3 bucket prefix to use for the registry")
 	rootCmd.PersistentFlags().StringVar(&flagS3Region, "storage-s3-region", "", "S3 bucket region to use for the registry")

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -155,6 +155,7 @@ var serverCmd = &cobra.Command{
 }
 
 func setupModuleStorage() (module.Storage, error) {
+	module.SetArchiveFormat(flagModuleArchiveFormat)
 	switch {
 	case flagS3Bucket != "":
 		return setupS3ModuleStorage()

--- a/pkg/module/service_test.go
+++ b/pkg/module/service_test.go
@@ -6,6 +6,7 @@ import (
 	"compress/gzip"
 	"context"
 	"io"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -94,6 +95,100 @@ func TestService_GetModule(t *testing.T) {
 			case false:
 				assert.NoError(err)
 				assert.Equal(tc.module, module)
+			}
+		})
+	}
+}
+
+func TestService_ListModuleVersions(t *testing.T) {
+	assert := assert.New(t)
+
+	testCases := []struct {
+		name        string
+		format      string
+		module      Module
+		versions    []string
+		data        io.Reader
+		expectError bool
+	}{
+		{
+			name: "valid list default format",
+			module: Module{
+				Namespace: "tier",
+				Name:      "s3",
+				Provider:  "aws",
+			},
+			versions: []string{"1.0.0", "2.4.1"},
+			data: testModuleData(map[string]string{
+				"main.tf": `name = "foo"`,
+			}),
+		},
+		{
+			name:   "valid list custom format",
+			format: "zip",
+			module: Module{
+				Namespace: "tier",
+				Name:      "s3",
+				Provider:  "aws",
+			},
+			versions: []string{"1.0.0", "2.4.1"},
+			data: testModuleData(map[string]string{
+				"main.tf": `name = "foo"`,
+			}),
+		},
+		{
+			name: "invalid list",
+			module: Module{
+				Namespace: "tier",
+				Name:      "s3",
+			},
+			versions: []string{"1.0.0"},
+			data: testModuleData(map[string]string{
+				"main.tf": `name = "foo"`,
+			}),
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			var (
+				ctx     = context.Background()
+				storage = NewInmemStorage()
+				svc     = NewService(storage)
+			)
+
+			// Make sure this test case is actually doing something
+			assert.NotEmpty(tc.versions)
+
+			for _, version := range tc.versions {
+				_, err := storage.UploadModule(ctx, tc.module.Namespace, tc.module.Name, tc.module.Provider, version, tc.data)
+				switch tc.expectError {
+				case true:
+					assert.Error(err)
+				case false:
+					assert.NoError(err)
+				}
+			}
+
+			SetArchiveFormat(tc.format)
+			modules, err := svc.ListModuleVersions(ctx, tc.module.Namespace, tc.module.Name, tc.module.Provider)
+			switch tc.expectError {
+			case true:
+				assert.Error(err)
+			case false:
+				assert.NoError(err)
+				versions := make([]string, 0)
+				for _, module := range modules {
+					assert.True(strings.HasSuffix(module.DownloadURL, "."+tc.format))
+					module.DownloadURL = ""
+					versions = append(versions, module.Version)
+					module.Version = ""
+					assert.Equal(tc.module, module)
+				}
+				assert.ElementsMatch(tc.versions, versions)
 			}
 		})
 	}

--- a/pkg/module/storage.go
+++ b/pkg/module/storage.go
@@ -7,6 +7,18 @@ import (
 	"path"
 )
 
+const (
+	DefaultArchiveFormat = "tar.gz"
+)
+
+var (
+	archiveFormat = DefaultArchiveFormat
+)
+
+func SetArchiveFormat(newFormat string) {
+	archiveFormat = newFormat
+}
+
 // Storage represents the repository of Terraform modules.
 type Storage interface {
 	GetModule(ctx context.Context, namespace, name, provider, version string) (Module, error)
@@ -30,6 +42,6 @@ func storagePath(prefix, namespace, name, provider, version string) string {
 		fmt.Sprintf("name=%s", name),
 		fmt.Sprintf("provider=%s", provider),
 		fmt.Sprintf("version=%s", version),
-		fmt.Sprintf("%s-%s-%s-%s.tar.gz", namespace, name, provider, version),
+		fmt.Sprintf("%s-%s-%s-%s.%s", namespace, name, provider, version, archiveFormat),
 	)
 }

--- a/pkg/module/storage_inmem.go
+++ b/pkg/module/storage_inmem.go
@@ -36,10 +36,15 @@ func (s *InmemStorage) ListModuleVersions(ctx context.Context, namespace, name, 
 
 	var modules []Module
 
-	for _, module := range modules {
+	for _, module := range s.modules {
 		if module.Namespace == namespace && module.Name == name && module.Provider == provider {
+			module.DownloadURL = storagePath("inmem", namespace, name, provider, module.Version)
 			modules = append(modules, module)
 		}
+	}
+
+	if len(modules) == 0 {
+		return nil, errors.Errorf("no modules found for namespace=%s name=%s provider=%s", namespace, name, provider)
 	}
 
 	return modules, nil


### PR DESCRIPTION
Introduced a new --storage-module-archive-format flag that dictates what the
filename suffix will be for module download links.