### PR TITLE
OB-11173: URL-encode module download URLs for S3

### DIFF
--- a/pkg/module/storage.go
+++ b/pkg/module/storage.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net/url"
 	"path"
 )
 
@@ -26,22 +27,36 @@ type Storage interface {
 	UploadModule(ctx context.Context, namespace, name, provider, version string, body io.Reader) (Module, error)
 }
 
-func storagePrefix(prefix, namespace, name, provider string) string {
+func storagePrefix(prefix, namespace, name, provider string, urlEncode bool) string {
+	delimiter := "="
+	if urlEncode {
+		urlEncodeAll(&delimiter, &namespace, &name, &provider)
+	}
 	return path.Join(
 		prefix,
-		fmt.Sprintf("namespace=%s", namespace),
-		fmt.Sprintf("name=%s", name),
-		fmt.Sprintf("provider=%s", provider),
+		fmt.Sprintf("namespace%s%s", delimiter, namespace),
+		fmt.Sprintf("name%s%s", delimiter, name),
+		fmt.Sprintf("provider%s%s", delimiter, provider),
 	)
 }
 
-func storagePath(prefix, namespace, name, provider, version string) string {
+func storagePath(prefix, namespace, name, provider, version string, urlEncode bool) string {
+	delimiter := "="
+	if urlEncode {
+		urlEncodeAll(&delimiter, &namespace, &name, &provider, &version)
+	}
 	return path.Join(
 		prefix,
-		fmt.Sprintf("namespace=%s", namespace),
-		fmt.Sprintf("name=%s", name),
-		fmt.Sprintf("provider=%s", provider),
-		fmt.Sprintf("version=%s", version),
+		fmt.Sprintf("namespace%s%s", delimiter, namespace),
+		fmt.Sprintf("name%s%s", delimiter, name),
+		fmt.Sprintf("provider%s%s", delimiter, provider),
+		fmt.Sprintf("version%s%s", delimiter, version),
 		fmt.Sprintf("%s-%s-%s-%s.%s", namespace, name, provider, version, archiveFormat),
 	)
+}
+
+func urlEncodeAll(strings ...*string) {
+	for _, s := range strings {
+		*s = url.QueryEscape(*s)
+	}
 }

--- a/pkg/module/storage_gcs.go
+++ b/pkg/module/storage_gcs.go
@@ -25,7 +25,7 @@ type GCSStorage struct {
 }
 
 func (s *GCSStorage) GetModule(ctx context.Context, namespace, name, provider, version string) (Module, error) {
-	o := s.sc.Bucket(s.bucket).Object(storagePath(s.bucketPrefix, namespace, name, provider, version))
+	o := s.sc.Bucket(s.bucket).Object(storagePath(s.bucketPrefix, namespace, name, provider, version, false))
 	attrs, err := o.Attrs(ctx)
 	if err != nil {
 		return Module{}, errors.Wrap(ErrNotFound, err.Error())
@@ -53,7 +53,7 @@ func (s *GCSStorage) GetModule(ctx context.Context, namespace, name, provider, v
 
 func (s *GCSStorage) ListModuleVersions(ctx context.Context, namespace, name, provider string) ([]Module, error) {
 	var modules []Module
-	prefix := storagePrefix(s.bucketPrefix, namespace, name, provider)
+	prefix := storagePrefix(s.bucketPrefix, namespace, name, provider, false)
 
 	query := &storage.Query{
 		Prefix: prefix,
@@ -100,7 +100,7 @@ func (s *GCSStorage) UploadModule(ctx context.Context, namespace, name, provider
 		return Module{}, errors.New("version not defined")
 	}
 
-	key := storagePath(s.bucketPrefix, namespace, name, provider, version)
+	key := storagePath(s.bucketPrefix, namespace, name, provider, version, false)
 	if _, err := s.GetModule(ctx, namespace, name, provider, version); err == nil {
 		return Module{}, errors.Wrap(ErrAlreadyExists, key)
 	}

--- a/pkg/module/storage_inmem.go
+++ b/pkg/module/storage_inmem.go
@@ -38,7 +38,7 @@ func (s *InmemStorage) ListModuleVersions(ctx context.Context, namespace, name, 
 
 	for _, module := range s.modules {
 		if module.Namespace == namespace && module.Name == name && module.Provider == provider {
-			module.DownloadURL = storagePath("inmem", namespace, name, provider, module.Version)
+			module.DownloadURL = storagePath("inmem", namespace, name, provider, module.Version, false)
 			modules = append(modules, module)
 		}
 	}


### PR DESCRIPTION
Adds URL encoding for download URLs for modules that are hosted in S3. Because presigned URLs are used for provider downloads, no encoding is necessary for those.

Tested locally by running `terraform init` with a Terraform script that referenced a module in a locally-running instance of boring registry with a version of `0.2.2-11.beta+g10b004b`. With this patch, the command succeeded; without the patch, the command failed.